### PR TITLE
added automatic detection of MS-GF+ filenames

### DIFF
--- a/R/read_msgf_data.R
+++ b/R/read_msgf_data.R
@@ -14,7 +14,21 @@
 #' head(MSnID::psms(msnid))
 
 #' @export
-read_msgf_data <- function(path_to_MSGF_results, suffix = "_syn.txt"){
+read_msgf_data <- function(path_to_MSGF_results, suffix = NULL){
+   
+   if (is.null(suffix)) {
+      for (pattern in c("_msgfplus_syn.txt$", "_msgfdb_syn.txt$", "_syn.txt$")) {
+         if (length(list.files(path_to_MSGF_results, pattern)) > 0) {
+            suffix <- pattern
+            break
+         }
+      }
+   }
+   
+   if (is.null(suffix) | (length(list.files(path_to_MSGF_results, suffix)) == 0)) {
+      stop("MS-GF+ results not found.")
+   }
+   
    msnid <- MSnID(".")
    # accession -> Protein
    # calculatedMassToCharge -> f(MH, Charge) MSnID:::.PROTON_MASS


### PR DESCRIPTION
An implementation of Matt Monroe's suggestion to reading MS-GF+ files locally.

If user does not provide a suffix, then by default PlexedPiper will check whether there are any files ending in "_msgfplus_syn.txt", "_msgfdb_syn.txt", or "_syn.txt", in that order.

If there are no matching files then throw an error.